### PR TITLE
duration.mli: is this a typo?

### DIFF
--- a/src/duration.mli
+++ b/src/duration.mli
@@ -11,7 +11,7 @@
     {e %%VERSION%% - {{:%%PKG_HOMEPAGE%% }homepage}}
 *)
 
-(** The type for a duration, exposed as an int64 to provider interoperability. *)
+(** The type for a duration, exposed as an int64 to provide interoperability. *)
 type t = int64
 
 (** [pp ppf t] prints the duration. *)


### PR DESCRIPTION
Hi, I was just reading the docs, and wondered about this word, is it meant to simply say "to provide interoperability"? Or is there a _provider_ concept I don't know about?