### PR TITLE
Duration.pp: microseconds suffix is now "μs" instead of "us"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Duration.pp: microseconds suffix is now "μs" instead of "us" (#8 by @MisterDA)
+
 ## 0.2.0 (2021-08-04)
 
 * 32 bit compatibility:

--- a/duration.ml
+++ b/duration.ml
@@ -1,4 +1,3 @@
-
 type t = int64
 
 let of_us_64 m =
@@ -157,4 +156,4 @@ let pp ppf t =
     else if ms > 0L then
       Format.fprintf ppf "%Ld.%03Ldms" ms us
     else (* if us > 0 then *)
-      Format.fprintf ppf "%Ld.%03Ldus" us ns
+      Format.fprintf ppf "%Ld.%03Ldμs" us ns


### PR DESCRIPTION
I think we mostly have Unicode everywhere, so why not print a beautiful μ?