### PR TITLE
Adds an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ on negative or out of bound input.
 [![Build Status](https://travis-ci.org/hannesm/duration.svg?branch=master)](https://travis-ci.org/hannesm/duration)
 
 [API Documentation](https://hannesm.github.io/duration/doc/) is available online.
+
+An simple example is given in the example directory.

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,17 @@
+# duration
+
+This example is for the duration library
+
+https://opam.ocaml.org/packages/duration
+
+# Source file
+
+`bin/main.ml`
+
+# Building and running
+
+`dune exec bin/main.exe`
+
+# Cleaning up
+
+`dune clean`

--- a/example/bin/dune
+++ b/example/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries duration))

--- a/example/bin/main.ml
+++ b/example/bin/main.ml
@@ -3,7 +3,7 @@
    of months, or clock changes, or about leap years, and so on. It believes
    that there are 8766 hours in a year. *)
 
-let go () =
+let () =
   Printf.printf "112 days is %Li\n"
     (Duration.of_day 112);
   Printf.printf "21 hours is %Li\n"
@@ -19,8 +19,3 @@ let go () =
   Format.pp_print_newline Format.std_formatter ();
   (* Represented as a float *)
   Printf.printf "As a float: %f\n" (Duration.to_f (Duration.of_hour 20))
-
-let () =
-  match Sys.argv with
-  | [|_|] -> go ()
-  | _ -> Printf.eprintf "duration example: unknown command line\n"

--- a/example/bin/main.ml
+++ b/example/bin/main.ml
@@ -1,0 +1,26 @@
+(* Duration provides a way of storing durations from one nanosecond to 584
+   years in a 64 bit integer. Note that it does not know the time, or lengths
+   of months, or clock changes, or about leap years, and so on. It believes
+   that there are 8766 hours in a year. *)
+
+let go () =
+  Printf.printf "112 days is %Li\n"
+    (Duration.of_day 112);
+  Printf.printf "21 hours is %Li\n"
+    (Duration.of_hour 21);
+  Printf.printf "112 days and 21 hours is %Li\n"
+    (Int64.add (Duration.of_day 112) (Duration.of_hour 21));
+  Printf.printf "Which is %Li milliseconds\n"
+    (Duration.to_ms_64 (Int64.add (Duration.of_day 112) (Duration.of_hour 21)));
+  (* Use the formatter to print to stdout *)
+  Duration.pp
+    Format.std_formatter
+    (Int64.add (Duration.of_day 112) (Duration.of_hour 21));
+  Format.pp_print_newline Format.std_formatter ();
+  (* Represented as a float *)
+  Printf.printf "As a float: %f\n" (Duration.to_f (Duration.of_hour 20))
+
+let () =
+  match Sys.argv with
+  | [|_|] -> go ()
+  | _ -> Printf.eprintf "duration example: unknown command line\n"

--- a/example/dune-project
+++ b/example/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(name duration_example)

--- a/example/dune-workspace
+++ b/example/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(env (dev (flags :standard -warn-error -A)))


### PR DESCRIPTION
Hello!

This pull request adds some examples to Duration. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please give any comments you have on this programme.