### PR TITLE
Add of_string_exn

### DIFF
--- a/duration.ml
+++ b/duration.ml
@@ -222,3 +222,7 @@ let of_string_exn str =
     | [] -> acc
     | _ -> invalid_arg "Invalid metric: %S" str in
   go 0L lst
+
+let of_string str =
+  try Ok (of_string_exn str)
+  with Invalid_argument msg -> Error (`Msg msg)

--- a/duration.ml
+++ b/duration.ml
@@ -161,21 +161,29 @@ let pp ppf t =
       Format.fprintf ppf "%Ld.%03Ldμs" us ns
 
 let is_digit = function '0' .. '9' -> true | _ -> false
-let is_metric = function 's' | 'm' | 'h' | 'd' | 'y' -> true | _ -> false
 
 let split_on fn str =
   let r = ref [] in
   let j = ref (String.length str) in
-  for i = String.length str - 1 downto 0 do
-    if fn str.[i] then begin
-      let sub = String.sub str (i+1) (!j - i - 1) in
-      let metric = `Metric str.[i] in
-      r := metric :: `Value sub :: !r;
-      j := i;
-    end
+  let i = ref (!j - 1) in
+  while !i >= 0 do
+    if fn str.[!i] then begin
+      let x = String.sub str (!i+1) (!j - !i - 1) in
+      let a = !i in
+      while decr i; !i >= 0 && fn str.[!i] do () done;
+      if !i >= 0 then begin
+        let y = String.sub str (!i+1) (a - !i) in
+        r := y :: x :: !r;
+        j := !i+1
+      end else begin
+        let y = String.sub str 0 (a+1) in
+        r := y :: x :: !r;
+        j := 0
+      end
+    end else decr i
   done;
-  let pre = String.sub str 0 !j in
-  `Value pre :: !r
+  let x = String.sub str 0 !j in
+  if String.length x > 0 then x :: !r else !r
 
 let of_metric chr v = match chr with
   | 's' -> of_sec v
@@ -186,23 +194,31 @@ let of_metric chr v = match chr with
   | chr -> invalid_arg "Invalid metric '%c'" chr
 
 let of_string_exn str =
-  let lst = split_on is_metric str in
+  let lst = split_on is_digit str in
   let metric_to_int = function
     | 's' -> 0 | 'm' -> 1 | 'h' -> 2 | 'd' -> 3 | 'y' -> 4
     | _ -> assert false in
-  let metrics = Array.make 5 false in
+  let metrics = Array.make 7 false in
   let rec go acc = function
-    | `Value v :: `Metric m :: rest ->
-        Format.printf ">>> %s\n%!" v;
-        Format.printf ">>> %c\n%!" m;
-        if metrics.(metric_to_int m)
-        then invalid_arg "Multiple use of the metric '%c'" m;
-        if String.for_all is_digit v = false && String.length v > 0
-        then invalid_arg "Invalid value %s%c" v m;
+    | v :: ("s" | "m" | "h" | "d" | "y" as m) :: rest ->
+        if metrics.(metric_to_int m.[0])
+        then invalid_arg "Multiple use of the metric '%s'" m;
         let v = int_of_string v in
-        metrics.(metric_to_int m) <- true;
-        let acc = Int64.add acc (of_metric m v) in
+        metrics.(metric_to_int m.[0]) <- true;
+        let acc = Int64.add acc (of_metric m.[0] v) in
         go acc rest
-    | [] | [`Value ""]-> acc
+    | v :: "ms" :: rest ->
+        if metrics.(5) then invalid_arg "Multiple use of the metric 'ms'";
+        let v = int_of_string v in
+        metrics.(5) <- true;
+        let acc = Int64.add acc (of_ms v) in
+        go acc rest
+    | v :: "ns" :: rest ->
+        if metrics.(6) then invalid_arg "Multiple use of the metric 'ns'";
+        let v = int_of_string v in
+        metrics.(6) <- true;
+        let acc = Int64.add acc (Int64.of_int v) in
+        go acc rest
+    | [] -> acc
     | _ -> invalid_arg "Invalid metric: %S" str in
   go 0L lst

--- a/duration.ml
+++ b/duration.ml
@@ -199,27 +199,33 @@ let of_string_exn str =
     | 's' -> 0 | 'm' -> 1 | 'h' -> 2 | 'd' -> 3 | 'y' | 'a' -> 4
     | _ -> assert false in
   let metrics = Array.make 7 false in
+  let to_int v =
+    try int_of_string v
+    with Failure _ -> invalid_arg "Invalid value in %S" str in
   let rec go acc = function
     | v :: ("s" | "m" | "h" | "d" | "y" | "a" as m) :: rest ->
         if metrics.(metric_to_int m.[0])
         then invalid_arg "Multiple use of the metric '%s'" m;
-        let v = int_of_string v in
+        let v = to_int v in
         metrics.(metric_to_int m.[0]) <- true;
         let acc = Int64.add acc (of_metric m.[0] v) in
         go acc rest
     | v :: "ms" :: rest ->
         if metrics.(5) then invalid_arg "Multiple use of the metric 'ms'";
-        let v = int_of_string v in
+        let v = to_int v in
         metrics.(5) <- true;
         let acc = Int64.add acc (of_ms v) in
         go acc rest
     | v :: "ns" :: rest ->
         if metrics.(6) then invalid_arg "Multiple use of the metric 'ns'";
-        let v = int_of_string v in
+        let v = to_int v in
         metrics.(6) <- true;
         let acc = Int64.add acc (Int64.of_int v) in
         go acc rest
-    | [] -> acc
+    | [] ->
+        if not (Array.exists (fun b -> b) metrics)
+        then invalid_arg "Invalid metric: %S" str;
+        acc
     | _ -> invalid_arg "Invalid metric: %S" str in
   go 0L lst
 

--- a/duration.ml
+++ b/duration.ml
@@ -1,3 +1,5 @@
+let invalid_arg fmt = Format.kasprintf invalid_arg fmt
+
 type t = int64
 
 let of_us_64 m =
@@ -157,3 +159,50 @@ let pp ppf t =
       Format.fprintf ppf "%Ld.%03Ldms" ms us
     else (* if us > 0 then *)
       Format.fprintf ppf "%Ld.%03Ldμs" us ns
+
+let is_digit = function '0' .. '9' -> true | _ -> false
+let is_metric = function 's' | 'm' | 'h' | 'd' | 'y' -> true | _ -> false
+
+let split_on fn str =
+  let r = ref [] in
+  let j = ref (String.length str) in
+  for i = String.length str - 1 downto 0 do
+    if fn str.[i] then begin
+      let sub = String.sub str (i+1) (!j - i - 1) in
+      let metric = `Metric str.[i] in
+      r := metric :: `Value sub :: !r;
+      j := i;
+    end
+  done;
+  let pre = String.sub str 0 !j in
+  `Value pre :: !r
+
+let of_metric chr v = match chr with
+  | 's' -> of_sec v
+  | 'm' -> of_min v
+  | 'h' -> of_hour v
+  | 'd' -> of_day v
+  | 'y' -> of_year v
+  | chr -> invalid_arg "Invalid metric '%c'" chr
+
+let of_string_exn str =
+  let lst = split_on is_metric str in
+  let metric_to_int = function
+    | 's' -> 0 | 'm' -> 1 | 'h' -> 2 | 'd' -> 3 | 'y' -> 4
+    | _ -> assert false in
+  let metrics = Array.make 5 false in
+  let rec go acc = function
+    | `Value v :: `Metric m :: rest ->
+        Format.printf ">>> %s\n%!" v;
+        Format.printf ">>> %c\n%!" m;
+        if metrics.(metric_to_int m)
+        then invalid_arg "Multiple use of the metric '%c'" m;
+        if String.for_all is_digit v = false && String.length v > 0
+        then invalid_arg "Invalid value %s%c" v m;
+        let v = int_of_string v in
+        metrics.(metric_to_int m) <- true;
+        let acc = Int64.add acc (of_metric m v) in
+        go acc rest
+    | [] | [`Value ""]-> acc
+    | _ -> invalid_arg "Invalid metric: %S" str in
+  go 0L lst

--- a/duration.ml
+++ b/duration.ml
@@ -190,17 +190,17 @@ let of_metric chr v = match chr with
   | 'm' -> of_min v
   | 'h' -> of_hour v
   | 'd' -> of_day v
-  | 'y' -> of_year v
+  | 'y' | 'a' -> of_year v
   | chr -> invalid_arg "Invalid metric '%c'" chr
 
 let of_string_exn str =
   let lst = split_on is_digit str in
   let metric_to_int = function
-    | 's' -> 0 | 'm' -> 1 | 'h' -> 2 | 'd' -> 3 | 'y' -> 4
+    | 's' -> 0 | 'm' -> 1 | 'h' -> 2 | 'd' -> 3 | 'y' | 'a' -> 4
     | _ -> assert false in
   let metrics = Array.make 7 false in
   let rec go acc = function
-    | v :: ("s" | "m" | "h" | "d" | "y" as m) :: rest ->
+    | v :: ("s" | "m" | "h" | "d" | "y" | "a" as m) :: rest ->
         if metrics.(metric_to_int m.[0])
         then invalid_arg "Multiple use of the metric '%s'" m;
         let v = int_of_string v in
@@ -225,4 +225,4 @@ let of_string_exn str =
 
 let of_string str =
   try Ok (of_string_exn str)
-  with Invalid_argument msg -> Error (`Msg msg)
+  with Invalid_argument msg | Failure msg -> Error (`Msg msg)

--- a/duration.mli
+++ b/duration.mli
@@ -87,14 +87,18 @@ val to_f : t -> float
 val of_string_exn : string -> t
 (** [of_string_exn str] tries to parse [str] and calculate a duration. The user
     can specify a duration via metrics:
-    - [1d] for one day
+    - [1ns] for one nanoseconds
+    - [1ms] for one milliseconds
     - [1s] for one second
     - [1m] for one minute
     - [1h] for one hour
-    - [1y] for one year
+    - [1d] for one day
+    - [1y]/[1a] for one year
 
     The user can use multiple metrics but they can be used only once. [1d1d] is
-    invalid (and you should prefer [2d]) but [1d1y] is valid and correspond to
+    invalid (you can use [2d]) but [1d1y] is valid and correspond to
     1 year plus 1 day. *)
 
 val of_string : string -> (t, [> `Msg of string ]) result
+(** [of_string] is {!val:of_string_exn} but it returns a result instead of
+    raising an exception. *)

--- a/duration.mli
+++ b/duration.mli
@@ -11,7 +11,7 @@
     {e %%VERSION%% - {{:%%PKG_HOMEPAGE%% }homepage}}
 *)
 
-(** The type for a duration, exposed as an int64 to provide interoperability. *)
+(** The type for a duration (in nanoseconds), exposed as an int64 to provide interoperability. *)
 type t = int64
 
 (** [pp ppf t] prints the duration in a concise way. *)
@@ -84,3 +84,15 @@ val to_year : t -> int
 (** [to_f t] is the floating point representation of [t]. *)
 val to_f : t -> float
 
+val of_string_exn : string -> t
+(** [of_string_exn str] tries to parse [str] and calculate a duration. The user
+    can specify a duration via metrics:
+    - [1d] for one day
+    - [1s] for one second
+    - [1m] for one minute
+    - [1h] for one hour
+    - [1y] for one year
+
+    The user can use multiple metrics but they can be used only once. [1d1d] is
+    invalid (and you should prefer [2d]) but [1d1y] is valid and correspond to
+    1 year plus 1 day. *)

--- a/duration.mli
+++ b/duration.mli
@@ -96,3 +96,5 @@ val of_string_exn : string -> t
     The user can use multiple metrics but they can be used only once. [1d1d] is
     invalid (and you should prefer [2d]) but [1d1y] is valid and correspond to
     1 year plus 1 day. *)
+
+val of_string : string -> (t, [> `Msg of string ]) result

--- a/tests.ml
+++ b/tests.ml
@@ -149,9 +149,8 @@ let test_of_string =
   Alcotest.(check int64) "1 year" (Duration.of_string_exn "1y") (Duration.of_year 1);
   let n = Duration.of_day 1 in
   let n = Int64.add (Duration.of_year 1) n in
-  Alcotest.(check int64) "1 day and 1 year"
-    (Duration.of_string_exn "1d1y") n
-
+  Alcotest.(check int64) "1 day and 1 year" (Duration.of_string_exn "1d1y") n;
+  Alcotest.(check int64) "1ns" (Duration.of_string_exn "1ns") 1L
 
 let dur_tests =
   List.flatten [

--- a/tests.ml
+++ b/tests.ml
@@ -142,6 +142,17 @@ let test_float = [
   "inverse of/to_f", `Quick, test_inv_f
 ]
 
+let test_of_string =
+  Alcotest.test_case "of_string_exn" `Quick @@ fun () ->
+  Alcotest.(check int64) "1 day" (Duration.of_string_exn "1d") (Duration.of_day 1);
+  Alcotest.(check int64) "42 day" (Duration.of_string_exn "42d") (Duration.of_day 42);
+  Alcotest.(check int64) "1 year" (Duration.of_string_exn "1y") (Duration.of_year 1);
+  let n = Duration.of_day 1 in
+  let n = Int64.add (Duration.of_year 1) n in
+  Alcotest.(check int64) "1 day and 1 year"
+    (Duration.of_string_exn "1d1y") n
+
+
 let dur_tests =
   List.flatten [
     test_of_us ;
@@ -151,7 +162,8 @@ let dur_tests =
     test_of_hour ;
     test_of_day ;
     test_of_year ;
-    test_float
+    test_float ;
+    [ test_of_string ];
   ]
 
 

--- a/tests.ml
+++ b/tests.ml
@@ -144,13 +144,123 @@ let test_float = [
 
 let test_of_string =
   Alcotest.test_case "of_string_exn" `Quick @@ fun () ->
-  Alcotest.(check int64) "1 day" (Duration.of_string_exn "1d") (Duration.of_day 1);
-  Alcotest.(check int64) "42 day" (Duration.of_string_exn "42d") (Duration.of_day 42);
-  Alcotest.(check int64) "1 year" (Duration.of_string_exn "1y") (Duration.of_year 1);
-  let n = Duration.of_day 1 in
-  let n = Int64.add (Duration.of_year 1) n in
-  Alcotest.(check int64) "1 day and 1 year" (Duration.of_string_exn "1d1y") n;
-  Alcotest.(check int64) "1ns" (Duration.of_string_exn "1ns") 1L
+  Alcotest.(check int64) "1s" (Duration.of_string_exn "1s") (Duration.of_sec 1);
+  Alcotest.(check int64) "1m" (Duration.of_string_exn "1m") (Duration.of_min 1);
+  Alcotest.(check int64) "1h" (Duration.of_string_exn "1h") (Duration.of_hour 1);
+  Alcotest.(check int64) "42d" (Duration.of_string_exn "42d") (Duration.of_day 42);
+  Alcotest.(check int64) "1y" (Duration.of_string_exn "1y") (Duration.of_year 1);
+  Alcotest.(check int64) "1ms" (Duration.of_string_exn "1ms") (Duration.of_ms 1);
+  Alcotest.(check int64) "1ns" (Duration.of_string_exn "1ns") 1L;
+  Alcotest.(check int64) "0s" (Duration.of_string_exn "0s") 0L;
+  Alcotest.(check int64) "0ns" (Duration.of_string_exn "0ns") 0L;
+  Alcotest.(check int64) "100ms" (Duration.of_string_exn "100ms") (Duration.of_ms 100);
+  Alcotest.(check int64) "500ns" (Duration.of_string_exn "500ns") 500L;
+  Alcotest.(check int64) "10h" (Duration.of_string_exn "10h") (Duration.of_hour 10);
+  Alcotest.(check int64) "42a" (Duration.of_string_exn "42a") (Duration.of_year 42)
+
+let test_of_string_composite =
+  let ( + ) = Int64.add in
+  Alcotest.test_case "of_string_exn: composite" `Quick @@ fun () ->
+  Alcotest.(check int64) "1h30m15s"
+    (Duration.of_string_exn "1h30m15s")
+    (Duration.of_hour 1 + Duration.of_min 30 + Duration.of_sec 15);
+  Alcotest.(check int64) "100ms500ns"
+    (Duration.of_string_exn "100ms500ns")
+    (Duration.of_ms 100 + 500L);
+  Alcotest.(check int64) "1m1s = 1s1m (order independence)"
+    (Duration.of_string_exn "1m1s")
+    (Duration.of_string_exn "1s1m");
+  Alcotest.(check int64) "all metrics: 1y1d1h1m1s1ms1ns"
+    (Duration.of_string_exn "1y1d1h1m1s1ms1ns")
+    (Duration.of_year 1 + Duration.of_day 1 + Duration.of_hour 1 +
+     Duration.of_min 1 + Duration.of_sec 1 + Duration.of_ms 1 + 1L);
+  Alcotest.(check int64) "1m30s"
+    (Duration.of_string_exn "1m30s")
+    (Duration.of_min 1 + Duration.of_sec 30);
+  Alcotest.(check int64) "1d12h"
+    (Duration.of_string_exn "1d12h")
+    (Duration.of_day 1 + Duration.of_hour 12);
+  Alcotest.(check int64) "1m1ms"
+    (Duration.of_string_exn "1m1ms")
+    (Duration.of_min 1 + Duration.of_ms 1);
+  Alcotest.(check int64) "1s1ns"
+    (Duration.of_string_exn "1s1ns")
+    (Duration.of_sec 1 + 1L);
+  Alcotest.(check int64) "1ms1s (ms before s)"
+    (Duration.of_string_exn "1ms1s")
+    (Duration.of_ms 1 + Duration.of_sec 1);
+  Alcotest.(check int64) "1ns1ms1s (ns, ms, s)"
+    (Duration.of_string_exn "1ns1ms1s")
+    (1L + Duration.of_ms 1 + Duration.of_sec 1)
+
+let check_raises_exn msg f =
+  let raised = try f (); false with _ -> true in
+  Alcotest.(check bool) msg true raised
+
+let test_of_string_duplicate_errors =
+  Alcotest.test_case "of_string_exn: duplicate metrics" `Quick @@ fun () ->
+  let invalid_argf fmt = Fmt.kstr (fun msg -> Invalid_argument msg) fmt in
+  Alcotest.check_raises "duplicate d" (invalid_argf "Multiple use of the metric 'd'")
+    (fun () -> ignore (Duration.of_string_exn "1d1d"));
+  Alcotest.check_raises "duplicate s" (invalid_argf "Multiple use of the metric 's'")
+    (fun () -> ignore (Duration.of_string_exn "1s1s"));
+  Alcotest.check_raises "duplicate ms" (invalid_argf "Multiple use of the metric 'ms'")
+    (fun () -> ignore (Duration.of_string_exn "1ms1ms"));
+  Alcotest.check_raises "duplicate ns" (invalid_argf "Multiple use of the metric 'ns'")
+    (fun () -> ignore (Duration.of_string_exn "1ns1ns"))
+
+let test_of_string_invalid_metric =
+  Alcotest.test_case "of_string_exn: invalid metric" `Quick @@ fun () ->
+  let invalid_argf fmt = Fmt.kstr (fun msg -> Invalid_argument msg) fmt in
+  Alcotest.check_raises "metric x" (invalid_argf "Invalid metric: \"1x\"")
+    (fun () -> ignore (Duration.of_string_exn "1x"));
+  Alcotest.check_raises "metric w" (invalid_argf "Invalid metric: \"1w\"")
+    (fun () -> ignore (Duration.of_string_exn "1w"));
+  Alcotest.check_raises "metric mn" (invalid_argf "Invalid metric: \"1mn\"")
+    (fun () -> ignore (Duration.of_string_exn "1mn"));
+  Alcotest.check_raises "metric D (uppercase)" (invalid_argf "Invalid metric: \"1D\"")
+    (fun () -> ignore (Duration.of_string_exn "1D"))
+
+let test_of_string_malformed =
+  Alcotest.test_case "of_string_exn: malformed input" `Quick @@ fun () ->
+  let invalid_argf fmt = Fmt.kstr (fun msg -> Invalid_argument msg) fmt in
+  Alcotest.check_raises "only metric d" (invalid_argf "Invalid metric: \"d\"")
+    (fun () -> ignore (Duration.of_string_exn "d"));
+  Alcotest.check_raises "only metric s" (invalid_argf "Invalid metric: \"s\"")
+    (fun () -> ignore (Duration.of_string_exn "s"));
+  Alcotest.check_raises "only number" (invalid_argf "Invalid metric: \"123\"")
+    (fun () -> ignore (Duration.of_string_exn "123"));
+  Alcotest.check_raises "trailing number" (invalid_argf "Invalid metric: \"1s2\"")
+    (fun () -> ignore (Duration.of_string_exn "1s2"));
+  Alcotest.check_raises "negative" (invalid_argf "Invalid metric: \"-1d\"")
+    (fun () -> ignore (Duration.of_string_exn "-1d"));
+  Alcotest.check_raises "decimal" (invalid_argf "Invalid metric: \"1.5s\"")
+    (fun () -> ignore (Duration.of_string_exn "1.5s"));
+  Alcotest.check_raises "spaces" (invalid_argf "Invalid metric: \"1 d\"")
+    (fun () -> ignore (Duration.of_string_exn "1 d"));
+  Alcotest.check_raises "metric before number" (invalid_argf "Invalid metric: \"d1\"")
+    (fun () -> ignore (Duration.of_string_exn "d1"));
+  Alcotest.check_raises "letters only" (invalid_argf "Invalid metric: \"abc\"")
+    (fun () -> ignore (Duration.of_string_exn "abc"))
+
+let test_of_string_overflow =
+  Alcotest.test_case "of_string_exn: out of range" `Quick @@ fun () ->
+  let invalid_argf fmt = Fmt.kstr (fun msg -> Invalid_argument msg) fmt in
+  Alcotest.check_raises "days out of range" (invalid_argf "out of range")
+    (fun () -> ignore (Duration.of_string_exn "999999d"));
+  Alcotest.check_raises "years out of range" (invalid_argf "out of range")
+    (fun () -> ignore (Duration.of_string_exn "1000y"))
+
+let test_of_string_empty =
+  Alcotest.test_case "of_string_exn: empty string" `Quick @@ fun () ->
+  let invalid_argf fmt = Fmt.kstr (fun msg -> Invalid_argument msg) fmt in
+  Alcotest.check_raises "empty string should raise" (invalid_argf "Invalid metric: \"\"")
+    (fun () -> ignore (Duration.of_string_exn ""))
+
+let test_string =
+  [ test_of_string; test_of_string_composite; test_of_string_duplicate_errors
+  ; test_of_string_invalid_metric; test_of_string_malformed
+  ; test_of_string_overflow; test_of_string_empty ]
 
 let dur_tests =
   List.flatten [
@@ -162,7 +272,7 @@ let dur_tests =
     test_of_day ;
     test_of_year ;
     test_float ;
-    [ test_of_string ];
+    test_string ;
   ]
 
 


### PR DESCRIPTION
It's a really simple function to be able to parse a duration and be usable with `cmdliner` (and `Arg.conv`). Some remaining points should be discussed:
- I currently use only seconds, minutes, hours, days and years. Should we handle nanoseconds, milliseconds, etc.?
- I noticed that the pretty printer use `a` for a year where `of_string_exn` use `y`. Which one we should use?
- We should continue to provide some tests

Let me know what do you think about this PR.