### PR TITLE
Support micro seconds in of_string

### DIFF
--- a/duration.ml
+++ b/duration.ml
@@ -158,6 +158,8 @@ let pp ppf t =
     else if ms > 0L then
       Format.fprintf ppf "%Ld.%03Ldms" ms us
     else (* if us > 0 then *)
+      (* We use greek small letter mu (μ) over micro sign (µ) as recommended by
+         The Unicode Consortium. *)
       Format.fprintf ppf "%Ld.%03Ldμs" us ns
 
 let is_digit = function '0' .. '9' -> true | _ -> false
@@ -198,7 +200,7 @@ let of_string_exn str =
   let metric_to_int = function
     | 's' -> 0 | 'm' -> 1 | 'h' -> 2 | 'd' -> 3 | 'y' | 'a' -> 4
     | _ -> assert false in
-  let metrics = Array.make 7 false in
+  let metrics = Array.make 8 false in
   let to_int v =
     try int_of_string v
     with Failure _ -> invalid_arg "Invalid value in %S" str in
@@ -216,10 +218,17 @@ let of_string_exn str =
         metrics.(5) <- true;
         let acc = Int64.add acc (of_ms v) in
         go acc rest
-    | v :: "ns" :: rest ->
-        if metrics.(6) then invalid_arg "Multiple use of the metric 'ns'";
+    | v :: ("us" | (* micro sign *) "µs" | (* greek small letter mu *) "μs" as metric) :: rest ->
+        if metrics.(6) then
+          invalid_arg "Multiple use of the metrics '%s'" metric;
         let v = to_int v in
         metrics.(6) <- true;
+        let acc = Int64.add acc (of_us v) in
+        go acc rest
+    | v :: "ns" :: rest ->
+        if metrics.(7) then invalid_arg "Multiple use of the metric 'ns'";
+        let v = to_int v in
+        metrics.(7) <- true;
         let acc = Int64.add acc (Int64.of_int v) in
         go acc rest
     | [] ->

--- a/duration.mli
+++ b/duration.mli
@@ -88,6 +88,7 @@ val of_string_exn : string -> t
 (** [of_string_exn str] tries to parse [str] and calculate a duration. The user
     can specify a duration via metrics:
     - [1ns] for one nanoseconds
+    - [1us], [1μs] or [1µs] for one microsecond
     - [1ms] for one milliseconds
     - [1s] for one second
     - [1m] for one minute

--- a/tests.ml
+++ b/tests.ml
@@ -156,7 +156,10 @@ let test_of_string =
   Alcotest.(check int64) "100ms" (Duration.of_string_exn "100ms") (Duration.of_ms 100);
   Alcotest.(check int64) "500ns" (Duration.of_string_exn "500ns") 500L;
   Alcotest.(check int64) "10h" (Duration.of_string_exn "10h") (Duration.of_hour 10);
-  Alcotest.(check int64) "42a" (Duration.of_string_exn "42a") (Duration.of_year 42)
+  Alcotest.(check int64) "42a" (Duration.of_string_exn "42a") (Duration.of_year 42);
+  Alcotest.(check int64) "11us" (Duration.of_string_exn "11us") (Duration.of_us 11);
+  Alcotest.(check int64) "12µs (micro sign)" (Duration.of_string_exn "12µs") (Duration.of_us 12);
+  Alcotest.(check int64) "13μs (greek small letter mu)" (Duration.of_string_exn "13μs") (Duration.of_us 13)
 
 let test_of_string_composite =
   let ( + ) = Int64.add in


### PR DESCRIPTION
Allowed formats are `11us`, `12µs` and `13μ` (the latter two are micro sign and greek small letter mu - two distinct unicode code points).

According to https://en.wikipedia.org/wiki/Micro-#Symbol_encoding_in_character_sets The Unicode Consortium recommends using greek small letter mu over micro sign so I added a comment in `to_string`.

CC @MisterDA who added μs in `to_string` and CC @dinosaure who added `of_string`.